### PR TITLE
Pin kubernetes-cni to 0.6.0-00

### DIFF
--- a/install_k8s/tasks/main.yml
+++ b/install_k8s/tasks/main.yml
@@ -29,7 +29,7 @@
     packages:
     - kubelet
     - kubeadm
-    - kubernetes-cni
+    - kubernetes-cni=0.6.0-00
 
 - name: Initialise kubeadm
   raw: kubeadm init


### PR DESCRIPTION
Addressing `kubelet : Depends: kubernetes-cni (= 0.6.0) but 0.6.0-02 is to be installed`.